### PR TITLE
Add static photo gallery, manifest loader, and auto thumbnail generat…

### DIFF
--- a/.github/workflows/generate-photos.yml
+++ b/.github/workflows/generate-photos.yml
@@ -1,0 +1,46 @@
+name: Generate photos thumbnails and manifest
+
+on:
+  push:
+    branches:
+      - '**'
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install ImageMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate thumbnails and manifest
+        run: |
+          bash scripts/generate-thumbs.sh
+
+      - name: Commit and push changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add assets/photos/thumbs assets/photos/manifest.json || true
+            git commit -m "ci: generate thumbnails and update manifest [skip ci]"
+            git push
+          else
+            echo "No changes to commit"
+          fi
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,9 @@
   - `bash scripts/generate-thumbs.sh` (uses `sips` on macOS or ImageMagick)
   - This writes `assets/photos/thumbs/` and updates `assets/photos/manifest.json`.
 - Add full images to `assets/photos/`; thumbs are produced automatically with center-cropped 400x400 squares.
+
+## CI Automation
+- On push, GitHub Actions runs `.github/workflows/generate-photos.yml` to:
+  - Generate/refresh thumbnails and `assets/photos/manifest.json`.
+  - Auto-commit results with `[skip ci]` to avoid loops.
+- You can still run the scripts locally for faster iteration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root-level static site served by GitHub Pages.
+- Key files: `index.html` (home), `photos.html` (placeholder), `style.css` (global CSS), `Cenotaph-Titling.otf` (font), `CNAME` (custom domain).
+- Add new pages as `*.html` at repo root and link them from the sidebar menu in `index.html`.
+
+## Build, Test, and Development Commands
+- No build step or package tooling required. Site deploys from `main` as-is.
+- Local preview: `python3 -m http.server 4000` then visit `http://localhost:4000`.
+- Alternative (Node): `npx serve .` if you prefer a simple server.
+- Note: `package-lock.json` is present but there is no `package.json`; Node tooling is not used for builds.
+
+## Coding Style & Naming Conventions
+- Indentation: 4 spaces in HTML/CSS to match existing files.
+- HTML: Use semantic tags where possible; keep navigation in the `.menu` inside the `.sidebar`.
+- CSS: Lowercase, hyphenated class names (e.g., `.sidebar`, `.menu`). Extend `style.css`; co-locate font-face and global rules there.
+- Assets: Keep font files at root (consistent with current setup). If adding images, prefer a new `assets/` folder and reference with relative paths (e.g., `assets/photos/cat.jpg`).
+
+## Testing Guidelines
+- No automated tests. Verify pages manually in modern browsers.
+- Check layout at common widths (mobile, tablet, desktop). Use browser dev tools or Lighthouse for quick accessibility/performance checks.
+- Ensure all new links are reachable and relative paths resolve locally and on GitHub Pages.
+
+## Commit & Pull Request Guidelines
+- Commits: Short, imperative summaries in present tense (e.g., "Add photos page", "Refine sidebar spacing"). Scope in body if needed.
+- PRs: Include a brief description of changes, before/after screenshots for visual tweaks, and link any related issues.
+- Keep changes focused; update navigation links when adding or renaming pages.
+
+## Security & Configuration Tips
+- Do not remove or rename `CNAME`; it configures the custom domain.
+- Host fonts/assets locally (current pattern) to avoid third-party dependency drift.
+
+## Photos: Thumbnails & Manifest
+- Generate thumbnails and manifest before committing:
+  - `bash scripts/generate-thumbs.sh` (uses `sips` on macOS or ImageMagick)
+  - This writes `assets/photos/thumbs/` and updates `assets/photos/manifest.json`.
+- Add full images to `assets/photos/`; thumbs are produced automatically with center-cropped 400x400 squares.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@
 - Ensure all new links are reachable and relative paths resolve locally and on GitHub Pages.
 
 ## Commit & Pull Request Guidelines
+- Workflow: Always create a feature branch (e.g., `feature/<short-name>`) for changes; avoid committing directly to `main`.
+- Commit cadence: Commit early and often with small, focused changes; write clear messages so history is easy to review.
 - Commits: Short, imperative summaries in present tense (e.g., "Add photos page", "Refine sidebar spacing"). Scope in body if needed.
 - PRs: Include a brief description of changes, before/after screenshots for visual tweaks, and link any related issues.
 - Keep changes focused; update navigation links when adding or renaming pages.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -5,6 +5,7 @@ Add static photo gallery, manifest loader, and auto thumbnail generation
 - Adds a responsive photo grid with a lightbox.
 - Auto-builds thumbnails and a manifest from `assets/photos/`.
 - Documents contributor workflow in AGENTS.md, including feature-branch workflow and frequent commits.
+- Adds CI workflow to auto-generate thumbnails and manifest on push.
 
 **Changes**
 - `photos.html`: Gallery markup, lightbox, loads `assets/photos/manifest.json` with a JS fallback.
@@ -13,6 +14,7 @@ Add static photo gallery, manifest loader, and auto thumbnail generation
 - `scripts/generate-photos-manifest.js`: Scans photos/thumbs and writes `assets/photos/manifest.json`.
 - `assets/photos/*` and `assets/photos/thumbs/*`: Placeholder images.
 - `AGENTS.md`: Repository guidelines and photos workflow; added requirement to create feature branches and commit regularly.
+- `.github/workflows/generate-photos.yml`: GitHub Actions workflow that installs ImageMagick, runs the thumbnail script, updates the manifest, and auto-commits with `[skip ci]`.
 
 **How To Test**
 - Local server: `python3 -m http.server 4000` then open `http://localhost:4000/photos.html`.
@@ -40,6 +42,7 @@ Add static photo gallery, manifest loader, and auto thumbnail generation
 - No impact to `index.html` nav (photos link already exists).
 - `CNAME` unchanged.
 - If neither `sips` nor ImageMagick is installed, thumbnails won’t be generated (script errors with guidance).
+- CI commits include `[skip ci]` to avoid triggering the workflow again.
 
 **Checklist**
 - [ ] Screenshots attached (desktop + mobile)
@@ -48,4 +51,3 @@ Add static photo gallery, manifest loader, and auto thumbnail generation
 - [ ] Cross-browser spot check (Safari/Chrome/Firefox)
 - [ ] Accessibility quick pass (keyboard nav, alt text)
 - [ ] Docs reflect branching/commit workflow
-

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,51 @@
+**Title**
+Add static photo gallery, manifest loader, and auto thumbnail generation
+
+**Summary**
+- Adds a responsive photo grid with a lightbox.
+- Auto-builds thumbnails and a manifest from `assets/photos/`.
+- Documents contributor workflow in AGENTS.md, including feature-branch workflow and frequent commits.
+
+**Changes**
+- `photos.html`: Gallery markup, lightbox, loads `assets/photos/manifest.json` with a JS fallback.
+- `style.css`: Gallery and lightbox styles.
+- `scripts/generate-thumbs.sh`: Creates 400x400 center-cropped thumbnails via `sips` or ImageMagick.
+- `scripts/generate-photos-manifest.js`: Scans photos/thumbs and writes `assets/photos/manifest.json`.
+- `assets/photos/*` and `assets/photos/thumbs/*`: Placeholder images.
+- `AGENTS.md`: Repository guidelines and photos workflow; added requirement to create feature branches and commit regularly.
+
+**How To Test**
+- Local server: `python3 -m http.server 4000` then open `http://localhost:4000/photos.html`.
+- Verify:
+  - Grid renders with 6 placeholders.
+  - Clicking opens lightbox; click overlay or press Escape to close.
+  - Responsive layout at mobile/tablet/desktop widths.
+
+**Usage**
+- Add full images to `assets/photos/`.
+- Generate thumbnails and manifest:
+  - `bash scripts/generate-thumbs.sh`
+  - (This also runs the manifest generator if Node is available.)
+- Commit `assets/photos/thumbs/` and `assets/photos/manifest.json`.
+
+**Screenshots**
+- Before: N/A (empty photos.html)
+- After: [Add desktop and mobile screenshots]
+
+**Accessibility**
+- Lightbox uses `role="dialog"`, `aria-hidden`, and Escape handling.
+- `alt` derived from filenames; editable in manifest if needed.
+
+**Risks / Notes**
+- No impact to `index.html` nav (photos link already exists).
+- `CNAME` unchanged.
+- If neither `sips` nor ImageMagick is installed, thumbnails won’t be generated (script errors with guidance).
+
+**Checklist**
+- [ ] Screenshots attached (desktop + mobile)
+- [ ] Thumbnails generated and manifest updated
+- [ ] Links verified (no 404s)
+- [ ] Cross-browser spot check (Safari/Chrome/Firefox)
+- [ ] Accessibility quick pass (keyboard nav, alt text)
+- [ ] Docs reflect branching/commit workflow
+

--- a/assets/photos/manifest.json
+++ b/assets/photos/manifest.json
@@ -1,33 +1,37 @@
 [
   {
+    "src": "assets/photos/manifest.json",
+    "thumb": "assets/photos/manifest.json",
+    "alt": "Manifest"
+  },
+  {
     "src": "assets/photos/photo1.svg",
     "thumb": "assets/photos/thumbs/photo1.svg",
-    "alt": "Photo 1"
+    "alt": "Photo1"
   },
   {
     "src": "assets/photos/photo2.svg",
     "thumb": "assets/photos/thumbs/photo2.svg",
-    "alt": "Photo 2"
+    "alt": "Photo2"
   },
   {
     "src": "assets/photos/photo3.svg",
     "thumb": "assets/photos/thumbs/photo3.svg",
-    "alt": "Photo 3"
+    "alt": "Photo3"
   },
   {
     "src": "assets/photos/photo4.svg",
     "thumb": "assets/photos/thumbs/photo4.svg",
-    "alt": "Photo 4"
+    "alt": "Photo4"
   },
   {
     "src": "assets/photos/photo5.svg",
     "thumb": "assets/photos/thumbs/photo5.svg",
-    "alt": "Photo 5"
+    "alt": "Photo5"
   },
   {
     "src": "assets/photos/photo6.svg",
     "thumb": "assets/photos/thumbs/photo6.svg",
-    "alt": "Photo 6"
+    "alt": "Photo6"
   }
 ]
-

--- a/assets/photos/manifest.json
+++ b/assets/photos/manifest.json
@@ -1,10 +1,5 @@
 [
   {
-    "src": "assets/photos/manifest.json",
-    "thumb": "assets/photos/manifest.json",
-    "alt": "Manifest"
-  },
-  {
     "src": "assets/photos/photo1.svg",
     "thumb": "assets/photos/thumbs/photo1.svg",
     "alt": "Photo1"

--- a/assets/photos/manifest.json
+++ b/assets/photos/manifest.json
@@ -1,0 +1,33 @@
+[
+  {
+    "src": "assets/photos/photo1.svg",
+    "thumb": "assets/photos/thumbs/photo1.svg",
+    "alt": "Photo 1"
+  },
+  {
+    "src": "assets/photos/photo2.svg",
+    "thumb": "assets/photos/thumbs/photo2.svg",
+    "alt": "Photo 2"
+  },
+  {
+    "src": "assets/photos/photo3.svg",
+    "thumb": "assets/photos/thumbs/photo3.svg",
+    "alt": "Photo 3"
+  },
+  {
+    "src": "assets/photos/photo4.svg",
+    "thumb": "assets/photos/thumbs/photo4.svg",
+    "alt": "Photo 4"
+  },
+  {
+    "src": "assets/photos/photo5.svg",
+    "thumb": "assets/photos/thumbs/photo5.svg",
+    "alt": "Photo 5"
+  },
+  {
+    "src": "assets/photos/photo6.svg",
+    "thumb": "assets/photos/thumbs/photo6.svg",
+    "alt": "Photo 6"
+  }
+]
+

--- a/assets/photos/photo1.svg
+++ b/assets/photos/photo1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ddd"/>
+      <stop offset="100%" stop-color="#bbb"/>
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#g1)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#333">Photo 1</text>
+</svg>

--- a/assets/photos/photo2.svg
+++ b/assets/photos/photo2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e6e6e6"/>
+      <stop offset="100%" stop-color="#c7c7c7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#g2)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#333">Photo 2</text>
+</svg>

--- a/assets/photos/photo3.svg
+++ b/assets/photos/photo3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <linearGradient id="g3" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#efefef"/>
+      <stop offset="100%" stop-color="#cfcfcf"/>
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#g3)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#333">Photo 3</text>
+</svg>

--- a/assets/photos/photo4.svg
+++ b/assets/photos/photo4.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <linearGradient id="g4" x1="1" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#f5f5f5"/>
+      <stop offset="100%" stop-color="#d5d5d5"/>
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#g4)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#333">Photo 4</text>
+</svg>

--- a/assets/photos/photo5.svg
+++ b/assets/photos/photo5.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <linearGradient id="g5" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#eaeaea"/>
+      <stop offset="100%" stop-color="#d0d0d0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#g5)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#333">Photo 5</text>
+</svg>

--- a/assets/photos/photo6.svg
+++ b/assets/photos/photo6.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+  <defs>
+    <linearGradient id="g6" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f0f0f0"/>
+      <stop offset="100%" stop-color="#d9d9d9"/>
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#g6)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#333">Photo 6</text>
+</svg>

--- a/assets/photos/thumbs/photo1.svg
+++ b/assets/photos/thumbs/photo1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="36" fill="#444">Thumb 1</text>
+</svg>

--- a/assets/photos/thumbs/photo2.svg
+++ b/assets/photos/thumbs/photo2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#dcdcdc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="36" fill="#444">Thumb 2</text>
+</svg>

--- a/assets/photos/thumbs/photo3.svg
+++ b/assets/photos/thumbs/photo3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#d8d8d8"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="36" fill="#444">Thumb 3</text>
+</svg>

--- a/assets/photos/thumbs/photo4.svg
+++ b/assets/photos/thumbs/photo4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#d3d3d3"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="36" fill="#444">Thumb 4</text>
+</svg>

--- a/assets/photos/thumbs/photo5.svg
+++ b/assets/photos/thumbs/photo5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#cfcfcf"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="36" fill="#444">Thumb 5</text>
+</svg>

--- a/assets/photos/thumbs/photo6.svg
+++ b/assets/photos/thumbs/photo6.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#cbcbcb"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="36" fill="#444">Thumb 6</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <nav class="menu">
             <a>HOME</a>
             <a>VIDEO</a>
-            <a>PHOTO</a>
+            <a href="./photos.html">PHOTO</a>
             <a>WEB</a>
         </nav>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "OKEnterprises.github.io",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/photos.html
+++ b/photos.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Photos — Garret O'Connor</title>
+    <meta name="description" content="Photo gallery">
+    <style>
+        /* Minimal fallback if style.css is cached */
+        .gallery{display:grid;gap:12px}
+    </style>
+    
+</head>
+<body>
+    <div class="sidebar">
+        <h1>Garret O'Connor</h1>
+        <nav class="menu">
+            <a href="./index.html">HOME</a>
+            <a>VIDEO</a>
+            <a href="./photos.html">PHOTO</a>
+            <a>WEB</a>
+        </nav>
+    </div>
+
+    <div class="gallery" id="gallery" aria-live="polite"></div>
+
+    <div class="lightbox" id="lightbox" aria-hidden="true" role="dialog" aria-label="Full-size image viewer" tabindex="-1">
+        <img id="lightbox-img" alt="">
+    </div>
+
+    <script>
+    (function(){
+        const gallery = document.getElementById('gallery');
+        const lightbox = document.getElementById('lightbox');
+        const lightboxImg = document.getElementById('lightbox-img');
+
+        function render(images){
+            images.forEach(item => {
+                const a = document.createElement('a');
+                a.href = item.src;
+                a.className = 'thumb';
+                a.setAttribute('aria-label', 'View full-size');
+                const img = document.createElement('img');
+                img.loading = 'lazy';
+                img.src = item.thumb || item.src;
+                img.alt = item.alt || deriveAlt(item.src);
+                a.appendChild(img);
+                a.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    openLightbox(item.src, img.alt);
+                });
+                gallery.appendChild(a);
+            });
+        }
+
+        function deriveAlt(src){
+            const base = src.split('/').pop().replace(/\.[^.]+$/, '').replace(/[-_]+/g, ' ').trim();
+            return base ? base.charAt(0).toUpperCase() + base.slice(1) : '';
+        }
+
+        function openLightbox(src, alt){
+            lightboxImg.src = src;
+            lightboxImg.alt = alt || '';
+            lightbox.classList.add('open');
+            lightbox.setAttribute('aria-hidden', 'false');
+            lightbox.focus();
+        }
+
+        function closeLightbox(){
+            lightbox.classList.remove('open');
+            lightbox.setAttribute('aria-hidden', 'true');
+            lightboxImg.src = '';
+        }
+
+        lightbox.addEventListener('click', closeLightbox);
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && lightbox.classList.contains('open')) closeLightbox();
+        });
+
+        // Prevent closing when clicking the image itself
+        lightboxImg.addEventListener('click', (e) => e.stopPropagation());
+
+        async function init(){
+            const manifestUrl = 'assets/photos/manifest.json';
+            let images = [];
+            try {
+                const res = await fetch(manifestUrl, { cache: 'no-store' });
+                if (!res.ok) throw new Error('Failed to load manifest');
+                images = await res.json();
+            } catch (e) {
+                images = [
+                    { src: 'assets/photos/photo1.svg', thumb: 'assets/photos/thumbs/photo1.svg' },
+                    { src: 'assets/photos/photo2.svg', thumb: 'assets/photos/thumbs/photo2.svg' },
+                    { src: 'assets/photos/photo3.svg', thumb: 'assets/photos/thumbs/photo3.svg' },
+                    { src: 'assets/photos/photo4.svg', thumb: 'assets/photos/thumbs/photo4.svg' },
+                    { src: 'assets/photos/photo5.svg', thumb: 'assets/photos/thumbs/photo5.svg' },
+                    { src: 'assets/photos/photo6.svg', thumb: 'assets/photos/thumbs/photo6.svg' },
+                ];
+            }
+            render(images);
+        }
+
+        init();
+    })();
+    </script>
+</body>
+</html>

--- a/scripts/generate-photos-manifest.js
+++ b/scripts/generate-photos-manifest.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/*
+Generates assets/photos/manifest.json from files in assets/photos and assets/photos/thumbs.
+Usage: node scripts/generate-photos-manifest.js
+*/
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const photosDir = path.join(root, 'assets', 'photos');
+const thumbsDir = path.join(photosDir, 'thumbs');
+const manifestPath = path.join(photosDir, 'manifest.json');
+
+function isFile(p) {
+  try { return fs.statSync(p).isFile(); } catch { return false; }
+}
+
+function titleCase(s) {
+  return s.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim()
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function main(){
+  if (!fs.existsSync(photosDir)) {
+    console.error('Missing directory:', photosDir);
+    process.exit(1);
+  }
+
+  const all = fs.readdirSync(photosDir)
+    .filter(name => name !== 'thumbs')
+    .filter(name => isFile(path.join(photosDir, name)));
+
+  const thumbs = fs.existsSync(thumbsDir) ? fs.readdirSync(thumbsDir).filter(name => isFile(path.join(thumbsDir, name))) : [];
+
+  function findThumb(base) {
+    // Prefer exact same basename (any extension)
+    const re = new RegExp('^' + base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\.', 'i');
+    const match = thumbs.find(t => re.test(t));
+    return match ? 'assets/photos/thumbs/' + match : null;
+  }
+
+  const entries = all.map(filename => {
+    const ext = path.extname(filename);
+    const base = path.basename(filename, ext);
+    const src = `assets/photos/${filename}`;
+    const thumb = findThumb(base) || src;
+    const alt = titleCase(base);
+    return { src, thumb, alt };
+  }).sort((a,b) => a.src.localeCompare(b.src));
+
+  fs.writeFileSync(manifestPath, JSON.stringify(entries, null, 2) + '\n');
+  console.log('Wrote', manifestPath, `(${entries.length} items)`);
+}
+
+main();
+

--- a/scripts/generate-photos-manifest.js
+++ b/scripts/generate-photos-manifest.js
@@ -10,6 +10,7 @@ const root = path.join(__dirname, '..');
 const photosDir = path.join(root, 'assets', 'photos');
 const thumbsDir = path.join(photosDir, 'thumbs');
 const manifestPath = path.join(photosDir, 'manifest.json');
+const allowedExt = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.svg', '.avif']);
 
 function isFile(p) {
   try { return fs.statSync(p).isFile(); } catch { return false; }
@@ -27,10 +28,15 @@ function main(){
   }
 
   const all = fs.readdirSync(photosDir)
-    .filter(name => name !== 'thumbs')
-    .filter(name => isFile(path.join(photosDir, name)));
+    .filter(name => name !== 'thumbs' && name !== 'manifest.json' && !name.startsWith('.'))
+    .filter(name => {
+      const p = path.join(photosDir, name);
+      return isFile(p) && allowedExt.has(path.extname(name).toLowerCase());
+    });
 
-  const thumbs = fs.existsSync(thumbsDir) ? fs.readdirSync(thumbsDir).filter(name => isFile(path.join(thumbsDir, name))) : [];
+  const thumbs = fs.existsSync(thumbsDir)
+    ? fs.readdirSync(thumbsDir).filter(name => isFile(path.join(thumbsDir, name)) && allowedExt.has(path.extname(name).toLowerCase()))
+    : [];
 
   function findThumb(base) {
     // Prefer exact same basename (any extension)
@@ -53,4 +59,3 @@ function main(){
 }
 
 main();
-

--- a/scripts/generate-thumbs.sh
+++ b/scripts/generate-thumbs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PHOTOS_DIR="assets/photos"
+THUMBS_DIR="$PHOTOS_DIR/thumbs"
+SIZE="400x400"
+
+if [[ ! -d "$PHOTOS_DIR" ]]; then
+  echo "Error: $PHOTOS_DIR not found" >&2
+  exit 1
+fi
+
+mkdir -p "$THUMBS_DIR"
+
+# Choose tool: prefer sips on macOS, fallback to ImageMagick
+if command -v sips >/dev/null 2>&1; then
+  TOOL="sips"
+elif command -v magick >/dev/null 2>&1; then
+  TOOL="magick"
+elif command -v convert >/dev/null 2>&1; then
+  TOOL="convert"
+else
+  echo "Error: need 'sips' (macOS) or ImageMagick ('magick'/'convert') installed" >&2
+  exit 1
+fi
+
+process_imagemagick() {
+  local src="$1" dest="$2"
+  if command -v magick >/dev/null 2>&1; then
+    magick convert "$src" -auto-orient -thumbnail ${SIZE}^ -gravity center -extent $SIZE -quality 82 "$dest"
+  else
+    convert "$src" -auto-orient -thumbnail ${SIZE}^ -gravity center -extent $SIZE -quality 82 "$dest"
+  fi
+}
+
+process_sips() {
+  local src="$1" dest="$2"
+  # Query original dimensions
+  local info width height
+  info=$(sips -g pixelWidth -g pixelHeight "$src" 2>/dev/null)
+  width=$(echo "$info" | awk '/pixelWidth/ {print $2}')
+  height=$(echo "$info" | awk '/pixelHeight/ {print $2}')
+  # Work on a temp file to avoid mutating originals
+  local tmp
+  tmp=$(mktemp -t thumb.XXXXXX)
+  cp "$src" "$tmp"
+  # Resize so the smaller dimension is 400, then center-crop to 400x400
+  if [[ -n "$width" && -n "$height" && "$width" -gt "$height" ]]; then
+    sips --resampleHeight 400 "$tmp" >/dev/null
+  else
+    sips --resampleWidth 400 "$tmp" >/dev/null
+  fi
+  sips --cropToHeightWidth 400 400 "$tmp" >/dev/null
+  mv "$tmp" "$dest"
+}
+
+echo "Generating thumbnails to $THUMBS_DIR using $TOOL..."
+
+# Find images in PHOTOS_DIR (excluding thumbs and manifest)
+while IFS= read -r -d '' src; do
+  base_name=$(basename "$src")
+  name_no_ext=${base_name%.*}
+  ext=${base_name##*.}
+
+  # Skip manifest and hidden files
+  [[ "$base_name" == "manifest.json" ]] && continue
+  [[ "$base_name" == .* ]] && continue
+
+  dest="$THUMBS_DIR/$name_no_ext.$ext"
+
+  # SVG: just copy (no rasterizer assumed)
+  if [[ "$ext" =~ ^([sS][vV][gG])$ ]]; then
+    if [[ ! -f "$dest" || "$dest" -ot "$src" ]]; then
+      cp "$src" "$dest"
+      echo "Copied SVG thumb: $base_name"
+    fi
+    continue
+  fi
+
+  # Skip if up-to-date
+  if [[ -f "$dest" && "$dest" -nt "$src" ]]; then
+    continue
+  fi
+
+  case "$TOOL" in
+    sips)
+      process_sips "$src" "$dest"
+      ;;
+    magick|convert)
+      process_imagemagick "$src" "$dest"
+      ;;
+  esac
+  echo "Thumb: $base_name -> $(basename "$dest")"
+done < <(find "$PHOTOS_DIR" -maxdepth 1 -type f -print0)
+
+# Refresh manifest if the generator exists
+if [[ -f scripts/generate-photos-manifest.js ]]; then
+  if command -v node >/dev/null 2>&1; then
+    node scripts/generate-photos-manifest.js || true
+  else
+    echo "Note: Node not found; skipping manifest generation" >&2
+  fi
+fi
+
+echo "Done."
+

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@
 body {
     display: grid;
     grid-template-columns: 3fr 10fr;
-    margin: 0;
+    margin: 0; 
 }
 
 .sidebar {
@@ -18,17 +18,75 @@ body {
     background-color: blanchedalmond;
 }
 
-.sidebar h1 {
-    padding-bottom: 1em;
+.sidebar > h1 {
+    /* padding-bottom: 1em; */
     font-family: "Cenotaph";
-    font-size: 1.75em;
+    font-size: 2.25em;
+    text-decoration: underline 0.1em;
 }
 
 .menu {
     display: flex;
     flex-direction: column;
-    flex: 0.75;
-    justify-content: space-between;
+    flex: 0.9;
+    height: 100%;
+    justify-content: space-around;
     align-items: center;
-    font-size: larger;
+    font-size: 1.5em;
+}
+
+.menu a {
+    text-decoration: none;
+    color: #000;
+}
+
+.menu a:hover {
+    text-decoration: ;    
+}
+
+/* Gallery layout */
+.gallery {
+    grid-column: 2;
+    padding: 24px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 12px;
+    align-content: start;
+}
+
+.gallery .thumb {
+    display: block;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #f6f6f6;
+}
+
+.gallery img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    aspect-ratio: 1 / 1;
+    display: block;
+}
+
+/* Lightbox */
+.lightbox {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.lightbox.open {
+    display: flex;
+}
+
+.lightbox img {
+    max-width: 90vw;
+    max-height: 90vh;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    border-radius: 6px;
 }


### PR DESCRIPTION
**Summary**
- Adds a responsive photo grid with a lightbox.
- Auto-builds thumbnails and a manifest from `assets/photos/`.
- Documents contributor workflow in AGENTS.md, including feature-branch workflow and frequent commits.
- Adds CI workflow to auto-generate thumbnails and manifest on push.

**Changes**
- `photos.html`: Gallery markup, lightbox, loads `assets/photos/manifest.json` with a JS fallback.
- `style.css`: Gallery and lightbox styles.
- `scripts/generate-thumbs.sh`: Creates 400x400 center-cropped thumbnails via `sips` or ImageMagick.
- `scripts/generate-photos-manifest.js`: Scans photos/thumbs and writes `assets/photos/manifest.json`.
- `assets/photos/*` and `assets/photos/thumbs/*`: Placeholder images.
- `AGENTS.md`: Repository guidelines and photos workflow; added requirement to create feature branches and commit regularly.
- `.github/workflows/generate-photos.yml`: GitHub Actions workflow that installs ImageMagick, runs the thumbnail script, updates the manifest, and auto-commits with `[skip ci]`.

**How To Test**
- Local server: `python3 -m http.server 4000` then open `http://localhost:4000/photos.html`.
- Verify:
  - Grid renders with 6 placeholders.
  - Clicking opens lightbox; click overlay or press Escape to close.
  - Responsive layout at mobile/tablet/desktop widths.

**Usage**
- Add full images to `assets/photos/`.
- Generate thumbnails and manifest:
  - `bash scripts/generate-thumbs.sh`
  - (This also runs the manifest generator if Node is available.)
- Commit `assets/photos/thumbs/` and `assets/photos/manifest.json`.

**Screenshots**
- Before: N/A (empty photos.html)
- After: [Add desktop and mobile screenshots]

**Accessibility**
- Lightbox uses `role="dialog"`, `aria-hidden`, and Escape handling.
- `alt` derived from filenames; editable in manifest if needed.

**Risks / Notes**
- No impact to `index.html` nav (photos link already exists).
- `CNAME` unchanged.
- If neither `sips` nor ImageMagick is installed, thumbnails won’t be generated (script errors with guidance).
- CI commits include `[skip ci]` to avoid triggering the workflow again.

**Checklist**
- [ X ] Screenshots attached (desktop + mobile)
- [ X ] Thumbnails generated and manifest updated
- [ X ] Links verified (no 404s)
- [ ] Cross-browser spot check (Safari/Chrome/Firefox)
- [  ] Accessibility quick pass (keyboard nav, alt text)
- [ X ] Docs reflect branching/commit workflow

<img width="1552" height="987" alt="image" src="https://github.com/user-attachments/assets/9d45f62b-426a-4981-998c-6b59c570d67d" />

