### PR TITLE
Change name font to Cinzel

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <title>Garret O'Connor</title>
 </head>

--- a/photos.html
+++ b/photos.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <title>Photos — Garret O'Connor</title>
     <meta name="description" content="Photo gallery">

--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ body { margin: 0; }
 .sidebar > h1 { margin: 24px 0 8px; }
 
 .site-title {
-    font-family: "OptimaCustom", "Cenotaph", serif;
+    font-family: "Cinzel", "Cenotaph", serif;
     font-size: 2.5em;
     text-align: center;
 }

--- a/videos.html
+++ b/videos.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <title>Videos — Garret O'Connor</title>
     <meta name="description" content="Video gallery">


### PR DESCRIPTION
Replace OptimaCustom with Cinzel (Google Font) for the .site-title class. Add Google Fonts preconnect and stylesheet links to all HTML pages.