### PR TITLE
Remove bold formatting from user name

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,7 @@ body { margin: 0; }
     font-family: "Cinzel", "Cenotaph", serif;
     font-size: 2.5em;
     text-align: center;
+    font-weight: normal;
 }
 
 .menu {


### PR DESCRIPTION
Set font-weight to normal for .site-title class to make the name appear with regular weight instead of the default h1 bold.