### PR TITLE
Reorganize navigation and header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
 </head>
 <body>
     <main class="home">
-        <h1 class="site-title">Garret O'Connor</h1>
+        <a href="./index.html" class="site-title-link"><h1 class="site-title">Garret O'Connor</h1></a>
         <nav class="top-menu">
             <a href="./photos.html">PHOTO</a>
             <a href="./videos.html">VIDEO</a>
-            <a>WEB</a>
+            <a>BLOG</a>
         </nav>
     </main>
     

--- a/photos.html
+++ b/photos.html
@@ -17,12 +17,11 @@
 </head>
 <body>
     <header class="top-nav">
-        <h1 class="site-title">Garret O'Connor</h1>
+        <a href="./index.html" class="site-title-link"><h1 class="site-title">Garret O'Connor</h1></a>
         <nav class="top-menu">
-            <a href="./index.html">HOME</a>
-            <a href="./videos.html">VIDEO</a>
             <a href="./photos.html">PHOTO</a>
-            <a>WEB</a>
+            <a href="./videos.html">VIDEO</a>
+            <a>BLOG</a>
         </nav>
     </header>
 

--- a/style.css
+++ b/style.css
@@ -29,6 +29,11 @@ body { margin: 0; }
     margin: 0;
 }
 
+.site-title-link {
+    text-decoration: none;
+    color: inherit;
+}
+
 .top-menu {
     display: flex;
     gap: 24px;

--- a/videos.html
+++ b/videos.html
@@ -15,12 +15,11 @@
 </head>
 <body>
     <header class="top-nav">
-        <h1 class="site-title">Garret O'Connor</h1>
+        <a href="./index.html" class="site-title-link"><h1 class="site-title">Garret O'Connor</h1></a>
         <nav class="top-menu">
-            <a href="./index.html">HOME</a>
-            <a href="./videos.html">VIDEO</a>
             <a href="./photos.html">PHOTO</a>
-            <a>WEB</a>
+            <a href="./videos.html">VIDEO</a>
+            <a>BLOG</a>
         </nav>
     </header>
 


### PR DESCRIPTION
Reorganize navigation: make name clickable, rename WEB to BLOG, remove HOME link

- Made site title (Garret O'Connor) clickable on all pages to return to home
- Changed "WEB" to "BLOG" across all navigation menus
- Reordered navigation to "PHOTO" "VIDEO" "BLOG" for consistency
- Removed "HOME" link from photos and videos pages (name serves this purpose)
- Added CSS styling for clickable site title to maintain appearance