### PR TITLE
Refine typography and spacing for professional polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600&family=Crimson+Pro:wght@200;300;400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <title>Garret O'Connor</title>
 </head>

--- a/photos.html
+++ b/photos.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600&family=Crimson+Pro:wght@200;300;400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <title>Photos — Garret O'Connor</title>
     <meta name="description" content="Photo gallery">

--- a/style.css
+++ b/style.css
@@ -10,23 +10,29 @@
 }
 
 /* Global reset for consistent layout */
-body { margin: 0; }
+body {
+    margin: 0;
+    background: linear-gradient(to bottom, #fafafa 0%, #f5f5f5 100%);
+    min-height: 100vh;
+}
 
 /* Top navigation header */
 .top-nav {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 24px 24px 16px;
-    gap: 16px;
+    padding: 32px 24px 20px;
+    gap: 20px;
 }
 
 .site-title {
-    font-family: "Cinzel", "Cenotaph", serif;
-    font-size: 2.5em;
+    font-family: "Cormorant Garamond", "Cenotaph", serif;
+    font-size: 3.25em;
     text-align: center;
-    font-weight: normal;
+    font-weight: 300;
+    letter-spacing: 0.02em;
     margin: 0;
+    color: #1a1a1a;
 }
 
 .site-title-link {
@@ -36,21 +42,41 @@ body { margin: 0; }
 
 .top-menu {
     display: flex;
-    gap: 24px;
+    gap: 32px;
     justify-content: center;
     align-items: center;
-    font-size: 1.1em;
+    font-size: 0.875em;
+    font-family: "Crimson Pro", serif;
+    font-weight: 300;
+    letter-spacing: 0.15em;
 }
 
 .top-menu a {
     text-decoration: none;
-    color: #000;
-    padding: 6px 10px;
-    border-radius: 6px;
+    color: #1a1a1a;
+    padding: 8px 4px;
+    position: relative;
+    transition: color 0.2s ease;
 }
 
 .top-menu a:hover {
-    text-decoration: underline;
+    color: #4a4a4a;
+}
+
+.top-menu a::after {
+    content: '';
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    width: 0;
+    height: 1px;
+    background: #1a1a1a;
+    transition: all 0.3s ease;
+    transform: translateX(-50%);
+}
+
+.top-menu a:hover::after {
+    width: 100%;
 }
 
 /* Gallery layout */
@@ -106,9 +132,10 @@ body { margin: 0; }
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 24px;
+    gap: 32px;
 }
 
 .home .site-title {
-    font-size: 2.75em;
+    font-size: 4em;
+    font-weight: 300;
 }

--- a/videos.html
+++ b/videos.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600&family=Crimson+Pro:wght@200;300;400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <title>Videos — Garret O'Connor</title>
     <meta name="description" content="Video gallery">


### PR DESCRIPTION
## Summary
- Replace Cinzel with Cormorant Garamond for a more sophisticated, editorial aesthetic
- Add Crimson Pro for navigation with refined letter-spacing
- Improve spacing proportions and increase gap sizes throughout
- Add subtle gradient background (#fafafa to #f5f5f5)
- Implement elegant center-out underline animation on navigation hover
- Update photos.html and videos.html to maintain consistent typography across all pages
- Use professional color palette (#1a1a1a instead of pure black)

## Test plan
- [x] Verify homepage displays with Cormorant Garamond title and Crimson Pro navigation
- [ ] Check that photo and video gallery pages have consistent typography
- [ ] Test navigation hover animations work smoothly
- [ ] Confirm gradient background appears correctly
- [ ] Verify spacing feels more polished and professional

🤖 Generated with [Claude Code](https://claude.com/claude-code)