### PR TITLE
Simplify nav link hover to static underline

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,22 +61,8 @@ body {
 
 .top-menu a:hover {
     color: #4a4a4a;
-}
-
-.top-menu a::after {
-    content: '';
-    position: absolute;
-    bottom: 4px;
-    left: 50%;
-    width: 0;
-    height: 1px;
-    background: #1a1a1a;
-    transition: all 0.3s ease;
-    transform: translateX(-50%);
-}
-
-.top-menu a:hover::after {
-    width: 100%;
+    text-decoration: underline;
+    text-underline-offset: 3px;
 }
 
 /* Gallery layout */


### PR DESCRIPTION
## Summary
- Remove animated expanding underline effect on navigation links
- Replace with simple static underline on hover for a more minimalist feel

## Test plan
- [x] Verify nav links show a simple underline on hover
- [x] Confirm no animation/transition on the underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)